### PR TITLE
Fix "undefined method `IOError'" on bad dir

### DIFF
--- a/lib/grailbird_updater.rb
+++ b/lib/grailbird_updater.rb
@@ -20,7 +20,7 @@ class GrailbirdUpdater
     # @param file_path [String] path to file being read
     # @raise [IOError] if the required file isn't found
     def self.read_required(file_path)
-      raise IOError "#{file_path} must exist" unless File.exists?(file_path)
+      raise IOError, "#{file_path} must exist" unless File.exists?(file_path)
       read(file_path)
     end
 


### PR DESCRIPTION
If you tried to run on a directory that wasn't from a twitter archive you would get 

```
lib/grailbird_updater.rb:23:in `read_required': undefined method `IOError' for GrailbirdUpdater::JsFile:Class (NoMethodError)
```

Now you get the expected

```
lib/grailbird_updater.rb:23:in `read_required': ./data/js/user_details.js must exist (IOError)
```
