### PR TITLE
Use optimist gem instead of the deprecated trollop gem.

### DIFF
--- a/bin/grailbird_updater
+++ b/bin/grailbird_updater
@@ -6,12 +6,12 @@ require 'yaml'
 require 'json'
 require 'csv'
 require 'oauth'
-require 'trollop'
+require 'optimist'
 require 'colorize'
 
 require 'grailbird_updater'
 
-opts = Trollop::options do
+opts = Optimist::options do
     version "updater #{GrailbirdUpdater::VERSION}"
     banner <<-EOS
 Update your Twitter archive (best if used with a cron)

--- a/grailbird_updater.gemspec
+++ b/grailbird_updater.gemspec
@@ -6,6 +6,7 @@ require 'grailbird_updater/version'
 Gem::Specification.new do |gem|
   gem.name          = "grailbird_updater"
   gem.version       = GrailbirdUpdater::VERSION
+  gem.license       = "MIT"
   gem.authors       = ["Dannel Jurado"]
   gem.email         = ["dannelj@gmail.com"]
   gem.description   = %q{Twitter now allows you to download your tweets. This tool lets you keep that archive up to date.}
@@ -17,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency "oauth"
-  gem.add_dependency "trollop"
-  gem.add_dependency "colorize"
+  gem.add_dependency "oauth", "~> 0.5"
+  gem.add_dependency "optimist", "~> 3.0"
+  gem.add_dependency "colorize", "~> 0.8"
 end

--- a/lib/grailbird_updater/version.rb
+++ b/lib/grailbird_updater/version.rb
@@ -1,3 +1,3 @@
 class GrailbirdUpdater
-  VERSION = "0.5.1"
+  VERSION = "0.5.2"
 end


### PR DESCRIPTION
- The `trollop` gem has been deprecated and has been replaced by `optimist`
```
$ gem install trollop
Fetching: trollop-2.9.9.gem (100%)
!    The 'trollop' gem has been deprecated and has been replaced by 'optimist'.
!    See: https://rubygems.org/gems/optimist
!    And: https://github.com/ManageIQ/optimist
```

- Fix some minor warnings from `gem build`

* Add required .license field.
```
WARNING:  licenses is empty, but is recommended.  Use a license identifier from
http://spdx.org/licenses or 'Nonstandard' for a nonstandard license.
WARNING:  See http://guides.rubygems.org/specification-reference/ for help
```

* Provide some minimal semantic version for dependencies.
```
WARNING:  open-ended dependency on oauth (>= 0) is not recommended
  if oauth is semantically versioned, use:
    add_runtime_dependency 'oauth', '~> 0'
WARNING:  See http://guides.rubygems.org/specification-reference/ for help
```

- Bump `GrailbirdUpdater::VERSION` to `0.5.2` to signify new dependencies.